### PR TITLE
Replace the sandbox URL with Service URL for WSDLs in all services

### DIFF
--- a/src/main/java/jp/yahooapis/ss/v201901/account/AccountService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/account/AccountService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AccountService", targetNamespace = "http://ss.yahooapis.jp/V201901/Account", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AccountService?wsdl")
+@WebServiceClient(name = "AccountService", targetNamespace = "http://ss.yahooapis.jp/V201901/Account", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AccountService?wsdl")
 public class AccountService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AccountService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AccountService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AccountService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/accountshared/AccountSharedService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/accountshared/AccountSharedService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AccountSharedService", targetNamespace = "http://ss.yahooapis.jp/V201901/AccountShared", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AccountSharedService?wsdl")
+@WebServiceClient(name = "AccountSharedService", targetNamespace = "http://ss.yahooapis.jp/V201901/AccountShared", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AccountSharedService?wsdl")
 public class AccountSharedService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AccountSharedService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AccountSharedService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AccountSharedService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/accounttrackingurl/AccountTrackingUrlService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/accounttrackingurl/AccountTrackingUrlService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AccountTrackingUrlService", targetNamespace = "http://ss.yahooapis.jp/V201901/AccountTrackingUrl", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AccountTrackingURLService?wsdl")
+@WebServiceClient(name = "AccountTrackingUrlService", targetNamespace = "http://ss.yahooapis.jp/V201901/AccountTrackingUrl", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AccountTrackingURLService?wsdl")
 public class AccountTrackingUrlService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AccountTrackingUrlService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AccountTrackingURLService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AccountTrackingURLService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroup/AdGroupService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroup/AdGroupService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroup", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupService?wsdl")
+@WebServiceClient(name = "AdGroupService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroup", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupService?wsdl")
 public class AdGroupService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroupad/AdGroupAdService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroupad/AdGroupAdService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupAdService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupAd", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupAdService?wsdl")
+@WebServiceClient(name = "AdGroupAdService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupAd", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupAdService?wsdl")
 public class AdGroupAdService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupAdService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupAdService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupAdService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroupadlabel/AdGroupAdLabelService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroupadlabel/AdGroupAdLabelService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupAdLabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupAdLabel", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupAdLabelService?wsdl")
+@WebServiceClient(name = "AdGroupAdLabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupAdLabel", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupAdLabelService?wsdl")
 public class AdGroupAdLabelService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupAdLabelService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupAdLabelService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupAdLabelService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroupbidmultiplier/AdGroupBidMultiplierService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroupbidmultiplier/AdGroupBidMultiplierService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupBidMultiplierService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupBidMultiplier", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupBidMultiplierService?wsdl")
+@WebServiceClient(name = "AdGroupBidMultiplierService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupBidMultiplier", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupBidMultiplierService?wsdl")
 public class AdGroupBidMultiplierService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupBidMultiplierService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupBidMultiplierService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupBidMultiplierService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroupcriterion/AdGroupCriterionService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroupcriterion/AdGroupCriterionService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupCriterionService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupCriterion", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupCriterionService?wsdl")
+@WebServiceClient(name = "AdGroupCriterionService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupCriterion", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupCriterionService?wsdl")
 public class AdGroupCriterionService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupCriterionService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupCriterionService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupCriterionService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroupcriterionlabel/AdGroupCriterionLabelService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroupcriterionlabel/AdGroupCriterionLabelService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupCriterionLabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupCriterionLabel", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupCriterionLabelService?wsdl")
+@WebServiceClient(name = "AdGroupCriterionLabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupCriterionLabel", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupCriterionLabelService?wsdl")
 public class AdGroupCriterionLabelService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupCriterionLabelService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupCriterionLabelService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupCriterionLabelService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroupfeed/AdGroupFeedService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroupfeed/AdGroupFeedService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupFeedService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupFeed", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupFeedService?wsdl")
+@WebServiceClient(name = "AdGroupFeedService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupFeed", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupFeedService?wsdl")
 public class AdGroupFeedService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupFeedService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupFeedService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupFeedService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgrouplabel/AdGroupLabelService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgrouplabel/AdGroupLabelService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupLabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupLabel", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupLabelService?wsdl")
+@WebServiceClient(name = "AdGroupLabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupLabel", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupLabelService?wsdl")
 public class AdGroupLabelService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupLabelService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupLabelService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupLabelService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroupretargetinglist/AdGroupRetargetingListService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroupretargetinglist/AdGroupRetargetingListService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupRetargetingListService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupRetargetingList", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupRetargetingListService?wsdl")
+@WebServiceClient(name = "AdGroupRetargetingListService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupRetargetingList", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupRetargetingListService?wsdl")
 public class AdGroupRetargetingListService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupRetargetingListService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupRetargetingListService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupRetargetingListService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/adgroupwebpage/AdGroupWebpageService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/adgroupwebpage/AdGroupWebpageService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AdGroupWebpageService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupWebpage", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupWebpageService?wsdl")
+@WebServiceClient(name = "AdGroupWebpageService", targetNamespace = "http://ss.yahooapis.jp/V201901/AdGroupWebpage", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AdGroupWebpageService?wsdl")
 public class AdGroupWebpageService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AdGroupWebpageService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AdGroupWebpageService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AdGroupWebpageService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/auditlog/AuditLogService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/auditlog/AuditLogService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "AuditLogService", targetNamespace = "http://ss.yahooapis.jp/V201901/AuditLog", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/AuditLogService?wsdl")
+@WebServiceClient(name = "AuditLogService", targetNamespace = "http://ss.yahooapis.jp/V201901/AuditLog", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/AuditLogService?wsdl")
 public class AuditLogService
     extends Service
 {
@@ -30,7 +30,7 @@ public class AuditLogService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/AuditLogService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/AuditLogService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/balance/BalanceService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/balance/BalanceService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "BalanceService", targetNamespace = "http://ss.yahooapis.jp/V201901/Balance", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/BalanceService?wsdl")
+@WebServiceClient(name = "BalanceService", targetNamespace = "http://ss.yahooapis.jp/V201901/Balance", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/BalanceService?wsdl")
 public class BalanceService
     extends Service
 {
@@ -30,7 +30,7 @@ public class BalanceService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/BalanceService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/BalanceService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/biddingstrategy/BiddingStrategyService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/biddingstrategy/BiddingStrategyService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "BiddingStrategyService", targetNamespace = "http://ss.yahooapis.jp/V201901/BiddingStrategy", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/BiddingStrategyService?wsdl")
+@WebServiceClient(name = "BiddingStrategyService", targetNamespace = "http://ss.yahooapis.jp/V201901/BiddingStrategy", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/BiddingStrategyService?wsdl")
 public class BiddingStrategyService
     extends Service
 {
@@ -30,7 +30,7 @@ public class BiddingStrategyService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/BiddingStrategyService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/BiddingStrategyService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/bidlandscape/BidLandscapeService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/bidlandscape/BidLandscapeService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "BidLandscapeService", targetNamespace = "http://ss.yahooapis.jp/V201901/BidLandscape", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/BidLandscapeService?wsdl")
+@WebServiceClient(name = "BidLandscapeService", targetNamespace = "http://ss.yahooapis.jp/V201901/BidLandscape", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/BidLandscapeService?wsdl")
 public class BidLandscapeService
     extends Service
 {
@@ -30,7 +30,7 @@ public class BidLandscapeService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/BidLandscapeService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/BidLandscapeService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaign/CampaignService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaign/CampaignService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignService", targetNamespace = "http://ss.yahooapis.jp/V201901/Campaign", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignService?wsdl")
+@WebServiceClient(name = "CampaignService", targetNamespace = "http://ss.yahooapis.jp/V201901/Campaign", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignService?wsdl")
 public class CampaignService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaigncriterion/CampaignCriterionService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaigncriterion/CampaignCriterionService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignCriterionService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignCriterion", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignCriterionService?wsdl")
+@WebServiceClient(name = "CampaignCriterionService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignCriterion", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignCriterionService?wsdl")
 public class CampaignCriterionService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignCriterionService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignCriterionService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignCriterionService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaignexport/CampaignExportService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaignexport/CampaignExportService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignExportService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignExport", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignExportService?wsdl")
+@WebServiceClient(name = "CampaignExportService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignExport", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignExportService?wsdl")
 public class CampaignExportService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignExportService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignExportService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignExportService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaignfeed/CampaignFeedService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaignfeed/CampaignFeedService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignFeedService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignFeed", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignFeedService?wsdl")
+@WebServiceClient(name = "CampaignFeedService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignFeed", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignFeedService?wsdl")
 public class CampaignFeedService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignFeedService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignFeedService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignFeedService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaignlabel/CampaignLabelService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaignlabel/CampaignLabelService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignLabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignLabel", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignLabelService?wsdl")
+@WebServiceClient(name = "CampaignLabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignLabel", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignLabelService?wsdl")
 public class CampaignLabelService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignLabelService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignLabelService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignLabelService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaignretargetinglist/CampaignRetargetingListService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaignretargetinglist/CampaignRetargetingListService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignRetargetingListService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignRetargetingList", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignRetargetingListService?wsdl")
+@WebServiceClient(name = "CampaignRetargetingListService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignRetargetingList", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignRetargetingListService?wsdl")
 public class CampaignRetargetingListService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignRetargetingListService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignRetargetingListService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignRetargetingListService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaignsharedset/CampaignSharedSetService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaignsharedset/CampaignSharedSetService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignSharedSetService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignSharedSet", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignSharedSetService?wsdl")
+@WebServiceClient(name = "CampaignSharedSetService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignSharedSet", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignSharedSetService?wsdl")
 public class CampaignSharedSetService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignSharedSetService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignSharedSetService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignSharedSetService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaigntarget/CampaignTargetService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaigntarget/CampaignTargetService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignTargetService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignTarget", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignTargetService?wsdl")
+@WebServiceClient(name = "CampaignTargetService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignTarget", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignTargetService?wsdl")
 public class CampaignTargetService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignTargetService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignTargetService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignTargetService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/campaignwebpage/CampaignWebpageService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/campaignwebpage/CampaignWebpageService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "CampaignWebpageService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignWebpage", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/CampaignWebpageService?wsdl")
+@WebServiceClient(name = "CampaignWebpageService", targetNamespace = "http://ss.yahooapis.jp/V201901/CampaignWebpage", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/CampaignWebpageService?wsdl")
 public class CampaignWebpageService
     extends Service
 {
@@ -30,7 +30,7 @@ public class CampaignWebpageService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/CampaignWebpageService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/CampaignWebpageService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/conversiontracker/ConversionTrackerService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/conversiontracker/ConversionTrackerService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "ConversionTrackerService", targetNamespace = "http://ss.yahooapis.jp/V201901/ConversionTracker", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/ConversionTrackerService?wsdl")
+@WebServiceClient(name = "ConversionTrackerService", targetNamespace = "http://ss.yahooapis.jp/V201901/ConversionTracker", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/ConversionTrackerService?wsdl")
 public class ConversionTrackerService
     extends Service
 {
@@ -30,7 +30,7 @@ public class ConversionTrackerService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/ConversionTrackerService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/ConversionTrackerService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/dictionary/DictionaryService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/dictionary/DictionaryService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "DictionaryService", targetNamespace = "http://ss.yahooapis.jp/V201901/Dictionary", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/DictionaryService?wsdl")
+@WebServiceClient(name = "DictionaryService", targetNamespace = "http://ss.yahooapis.jp/V201901/Dictionary", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/DictionaryService?wsdl")
 public class DictionaryService
     extends Service
 {
@@ -30,7 +30,7 @@ public class DictionaryService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/DictionaryService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/DictionaryService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/feedfolder/FeedFolderService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/feedfolder/FeedFolderService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "FeedFolderService", targetNamespace = "http://ss.yahooapis.jp/V201901/FeedFolder", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/FeedFolderService?wsdl")
+@WebServiceClient(name = "FeedFolderService", targetNamespace = "http://ss.yahooapis.jp/V201901/FeedFolder", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/FeedFolderService?wsdl")
 public class FeedFolderService
     extends Service
 {
@@ -30,7 +30,7 @@ public class FeedFolderService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/FeedFolderService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/FeedFolderService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/feeditem/FeedItemService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/feeditem/FeedItemService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "FeedItemService", targetNamespace = "http://ss.yahooapis.jp/V201901/FeedItem", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/FeedItemService?wsdl")
+@WebServiceClient(name = "FeedItemService", targetNamespace = "http://ss.yahooapis.jp/V201901/FeedItem", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/FeedItemService?wsdl")
 public class FeedItemService
     extends Service
 {
@@ -30,7 +30,7 @@ public class FeedItemService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/FeedItemService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/FeedItemService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/keywordestimator/KeywordEstimatorService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/keywordestimator/KeywordEstimatorService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "KeywordEstimatorService", targetNamespace = "http://ss.yahooapis.jp/V201901/KeywordEstimator", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/KeywordEstimatorService?wsdl")
+@WebServiceClient(name = "KeywordEstimatorService", targetNamespace = "http://ss.yahooapis.jp/V201901/KeywordEstimator", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/KeywordEstimatorService?wsdl")
 public class KeywordEstimatorService
     extends Service
 {
@@ -30,7 +30,7 @@ public class KeywordEstimatorService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/KeywordEstimatorService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/KeywordEstimatorService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/label/LabelService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/label/LabelService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "LabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/Label", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/LabelService?wsdl")
+@WebServiceClient(name = "LabelService", targetNamespace = "http://ss.yahooapis.jp/V201901/Label", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/LabelService?wsdl")
 public class LabelService
     extends Service
 {
@@ -30,7 +30,7 @@ public class LabelService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/LabelService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/LabelService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/location/LocationService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/location/LocationService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "LocationService", targetNamespace = "http://ss.yahooapis.jp/V201901/Location", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/LocationService?wsdl")
+@WebServiceClient(name = "LocationService", targetNamespace = "http://ss.yahooapis.jp/V201901/Location", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/LocationService?wsdl")
 public class LocationService
     extends Service
 {
@@ -30,7 +30,7 @@ public class LocationService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/LocationService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/LocationService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/pagefeeditem/PageFeedItemService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/pagefeeditem/PageFeedItemService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "PageFeedItemService", targetNamespace = "http://ss.yahooapis.jp/V201901/PageFeedItem", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/PageFeedItemService?wsdl")
+@WebServiceClient(name = "PageFeedItemService", targetNamespace = "http://ss.yahooapis.jp/V201901/PageFeedItem", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/PageFeedItemService?wsdl")
 public class PageFeedItemService
     extends Service
 {
@@ -30,7 +30,7 @@ public class PageFeedItemService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/PageFeedItemService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/PageFeedItemService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/report/ReportService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/report/ReportService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "ReportService", targetNamespace = "http://ss.yahooapis.jp/V201901/Report", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/ReportService?wsdl")
+@WebServiceClient(name = "ReportService", targetNamespace = "http://ss.yahooapis.jp/V201901/Report", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/ReportService?wsdl")
 public class ReportService
     extends Service
 {
@@ -30,7 +30,7 @@ public class ReportService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/ReportService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/ReportService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/reportdefinition/ReportDefinitionService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/reportdefinition/ReportDefinitionService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "ReportDefinitionService", targetNamespace = "http://ss.yahooapis.jp/V201901/ReportDefinition", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/ReportDefinitionService?wsdl")
+@WebServiceClient(name = "ReportDefinitionService", targetNamespace = "http://ss.yahooapis.jp/V201901/ReportDefinition", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/ReportDefinitionService?wsdl")
 public class ReportDefinitionService
     extends Service
 {
@@ -30,7 +30,7 @@ public class ReportDefinitionService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/ReportDefinitionService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/ReportDefinitionService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/retargetinglist/RetargetingListService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/retargetinglist/RetargetingListService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "RetargetingListService", targetNamespace = "http://ss.yahooapis.jp/V201901/RetargetingList", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/RetargetingListService?wsdl")
+@WebServiceClient(name = "RetargetingListService", targetNamespace = "http://ss.yahooapis.jp/V201901/RetargetingList", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/RetargetingListService?wsdl")
 public class RetargetingListService
     extends Service
 {
@@ -30,7 +30,7 @@ public class RetargetingListService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/RetargetingListService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/RetargetingListService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/sharedcriterion/SharedCriterionService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/sharedcriterion/SharedCriterionService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "SharedCriterionService", targetNamespace = "http://ss.yahooapis.jp/V201901/SharedCriterion", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/SharedCriterionService?wsdl")
+@WebServiceClient(name = "SharedCriterionService", targetNamespace = "http://ss.yahooapis.jp/V201901/SharedCriterion", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/SharedCriterionService?wsdl")
 public class SharedCriterionService
     extends Service
 {
@@ -30,7 +30,7 @@ public class SharedCriterionService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/SharedCriterionService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/SharedCriterionService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }

--- a/src/main/java/jp/yahooapis/ss/v201901/targetingidea/TargetingIdeaService.java
+++ b/src/main/java/jp/yahooapis/ss/v201901/targetingidea/TargetingIdeaService.java
@@ -17,7 +17,7 @@ import javax.xml.ws.WebServiceFeature;
  * Generated source version: 2.2
  * 
  */
-@WebServiceClient(name = "TargetingIdeaService", targetNamespace = "http://ss.yahooapis.jp/V201901/TargetingIdea", wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/TargetingIdeaService?wsdl")
+@WebServiceClient(name = "TargetingIdeaService", targetNamespace = "http://ss.yahooapis.jp/V201901/TargetingIdea", wsdlLocation = "https://ss.yahooapis.jp/services/V201901/TargetingIdeaService?wsdl")
 public class TargetingIdeaService
     extends Service
 {
@@ -30,7 +30,7 @@ public class TargetingIdeaService
         URL url = null;
         WebServiceException e = null;
         try {
-            url = new URL("https://sandbox.ss.yahooapis.jp/services/V201901/TargetingIdeaService?wsdl");
+            url = new URL("https://ss.yahooapis.jp/services/V201901/TargetingIdeaService?wsdl");
         } catch (MalformedURLException ex) {
             e = new WebServiceException(ex);
         }


### PR DESCRIPTION
Currently all the Service files are referring to the following WSDL URLs : 
`wsdlLocation = "https://sandbox.ss.yahooapis.jp/services/V201901/*****Service?wsdl"`

Changed this to use the following WSDL URLs : 
`wsdlLocation = "https://ss.yahooapis.jp/services/V201901/*****Service?wsdl"`